### PR TITLE
reset #forkongithub back to box-sizing: content-box

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,6 +71,11 @@
     }
   </style>
   <style type="text/css-template" id="ribbon-tpl">
+    #forkongithub,
+    #forkongithub * {
+      box-sizing: content-box;
+    }
+    
     #forkongithub a {
       background: __bg__;
       color: __colour__;


### PR DESCRIPTION
Thank you for the lovely ribbon 👍 

Many css resets would now default everything to `box-sizing: border-box`.

Since the current styles relies on `content-box`, I have made the change to re-reset everything inside `#forkongithub` back to `content-box`.

<img width="309" alt="image" src="https://github.com/user-attachments/assets/1a132d22-3063-4d5b-9071-11ddc9ec6483" />

👆 what it looks like without this.

Thank you again ❤️